### PR TITLE
Fix cell_impl compiler warning

### DIFF
--- a/sodium/sodium.h
+++ b/sodium/sodium.h
@@ -51,7 +51,7 @@ namespace sodium {
     namespace impl {
 
         class cell_;
-        class cell_impl;
+        struct cell_impl;
 
         class stream_ {
         friend class cell_;


### PR DESCRIPTION
Hi there, I was just exploring your C++ implementation after reading the first chapter of your book and I found there was a compiler error when the warnings are strict enough:

```
sodium/sodium.h:297:9: error: 'cell_impl' defined as a struct here but previously
      declared as a class [-Werror,-Wmismatched-tags]
        struct cell_impl {
        ^
sodium/sodium.h:54:9: note: did you mean struct here?
        class cell_impl;
        ^~~~~
        struct
```

The cell_impl declaration was a class, where the implementation is a struct. This commit changes the declaration so that they match as a struct. Note the compiler warning was generated by Clang.

Hope this helps!