### PR TITLE
Fix compilation on PNaCl/Pepper

### DIFF
--- a/sodium/lock_pool.h
+++ b/sodium/lock_pool.h
@@ -82,13 +82,7 @@ namespace sodium {
         	return &lock_pool[0];
 #else
             spin_lock* l = &lock_pool[(uint32_t)((uint32_t)
-	#if __WORDSIZE == 32
-                (addr)
-	#elif __WORDSIZE == 64
-                (uint64_t)(addr)
-	#else
-	#error This architecture is not supported
-    #endif
+                (uintptr_t)(addr)
                 * (uint32_t)2654435761U) >> (32 - SODIUM_IMPL_LOCK_POOL_BITS)];
             l->lock();
             return l;
@@ -98,4 +92,3 @@ namespace sodium {
 }
 
 #endif
-

--- a/sodium/transaction.h
+++ b/sodium/transaction.h
@@ -74,7 +74,7 @@ namespace sodium {
 
         typedef unsigned long rank_t;
         #define SODIUM_IMPL_RANK_T_MAX ULONG_MAX
-        
+
         class holder;
 
         class node;
@@ -304,4 +304,3 @@ namespace sodium {
 }  // end namespace sodium
 
 #endif
-

--- a/sodium/transaction.h
+++ b/sodium/transaction.h
@@ -18,11 +18,7 @@
 #include <set>
 #include <list>
 #include <memory>
-#ifdef __linux
 #include <pthread.h>
-#else
-#include <pthread/pthread.h>
-#endif
 #include <forward_list>
 #include <tuple>
 


### PR DESCRIPTION
These changes fix compilation with Google's Portable Native Client toolchain.

Note that the changes *should* be portable to all platforms but there might be portability issues, especially on Windows:

* PNaCl doesn't define `__WORDSIZE` and I've used `uintptr_t` from `<stdint.h>` instead
* The location of the Pthread header should be `<pthread.h>` according to the [Open Group specification](http://pubs.opengroup.org/onlinepubs/7908799/xsh/pthread.h.html); I've compiled on OSX, iOS, Android and PNaCl and it should also compile on Linux
