### PR TITLE
Ported to windows by removing dependency on pthread.h

### DIFF
--- a/sodium/lock_pool.h
+++ b/sodium/lock_pool.h
@@ -13,7 +13,7 @@
 #include <libkern/OSAtomic.h>
 #elif defined(__TI_COMPILER_VERSION__)
 #else
-#include <pthread.h>
+#include <mutex>
 #endif
 #include <stdint.h>
 #include <limits.h>
@@ -51,20 +51,17 @@ namespace sodium {
             }
 #else
             bool initialized;
-            pthread_mutex_t m;
+            std::mutex m;
             spin_lock() : initialized(true) {
-                pthread_mutexattr_t attr;
-                pthread_mutexattr_init(&attr);
-                pthread_mutex_init(&m, &attr);
             }
             inline void lock() {
                 // Make sure nothing bad happens if this is called before the constructor.
                 // This can happen during static initialization if data structures that use
                 // this lock pool are declared statically.
-                if (initialized) pthread_mutex_lock(&m);
+                if (initialized) m.lock();
             }
             inline void unlock() {
-                if (initialized) pthread_mutex_unlock(&m);
+                if (initialized) m.unlock();
             }
 #endif
         };

--- a/sodium/sodium.h
+++ b/sodium/sodium.h
@@ -23,6 +23,11 @@
 
 #define SODIUM_CONSTANT_OPTIMIZATION
 
+#ifdef WIN32
+//maybe replace this with c++14 attributes..
+#define __attribute__(x)
+#endif
+
 // TO DO:
 // the sample_lazy() mechanism is not correct yet. The lazy value needs to be
 // fixed at the end of the transaction.

--- a/sodium/transaction.h
+++ b/sodium/transaction.h
@@ -18,44 +18,22 @@
 #include <set>
 #include <list>
 #include <memory>
-#include <pthread.h>
+#include <mutex>
 #include <forward_list>
 #include <tuple>
 
 namespace sodium {
 
-#if !defined(SODIUM_SINGLE_THREADED)
-    class mutex
-    {
-    private:
-        pthread_mutex_t mx;
-        // ensure we don't copy or assign a mutex by value
-        mutex(const mutex&) {}
-        mutex& operator = (const mutex&) { return *this; }
-    public:
-        mutex();
-        ~mutex();
-        void lock()
-        {
-            pthread_mutex_lock(&mx);
-        }
-        void unlock()
-        {
-            pthread_mutex_unlock(&mx);
-        }
-    };
-#endif
+    class transaction_impl;
 
     struct partition {
         partition();
         ~partition();
 #if !defined(SODIUM_SINGLE_THREADED)
-        mutex mx;
+        std::recursive_mutex mx;
 #endif
         int depth;
-#if !defined(SODIUM_SINGLE_THREADED)
-        pthread_key_t key;
-#endif
+
         bool processing_post;
         std::list<std::function<void()>> postQ;
         void post(std::function<void()> action);


### PR DESCRIPTION
All code for phtread.h is removed and has been replaced by c++11 mutex.
removed the class mutex completely replacing it with std::recursiv_mutex.
__attribute__ has been redefined for windows platform.