### PR TITLE
Allow to specify the accumulator type in stream::count()

### DIFF
--- a/sodium/sodium.h
+++ b/sodium/sodium.h
@@ -1181,10 +1181,11 @@ namespace sodium {
                 return cb;
             }
 
-            cell<int> count() const
+            template<class B = int>
+            cell<B> count(const B& initial=0) const
             {
-                return accum<int>(0,
-                    [] (const A&, const int& total) -> int {  return total+1; }
+                return accum<B>(initial,
+                    [] (const A&, const B& total) -> B { return total+1; }
                 );
             }
 


### PR DESCRIPTION
Allow to specify the type of the accumulator in `stream::count()` as a template argument, defaulting to `int`. Also allow to pass an initial accumulator value, defaulting to 0.